### PR TITLE
Add missing period after UV alert in summary text

### DIFF
--- a/bom-weather-card.js
+++ b/bom-weather-card.js
@@ -72,7 +72,7 @@ class BOMWeatherCard extends LitElement {
                 </div>`)}
               </div>
             <div class="summary clear" id="daily-summary-text">
-              ${summary} ${uv_alert} ${fire_danger}
+              ${summary} ${uv_alert}. ${fire_danger}
               </div>
       </ha-card>
     `;


### PR DESCRIPTION
Summary text gathered from BOM is presented in grammatically difficult way. Added missing period to aid reading flow.