### PR TITLE
Watch this._hass & .config, exit render if not set

### DIFF
--- a/bom-weather-card.js
+++ b/bom-weather-card.js
@@ -31,6 +31,7 @@ class BOMWeatherCard extends Lit {
 // #####
 
   render() {
+    if (!this.config || !this._hass) return html``;
 //  Handle Configuration Flags
 //    var icons = this.config.static_icons ? "static" : "animated";
     var currentText = this.config.entity_current_text ? html`<span class="currentText" id="current-text">${this._hass.states[this.config.entity_current_text].state}</span>` : ``;
@@ -872,6 +873,14 @@ style() {
       default:
         return this._hass.config.unit_system[measure] || '';
     }
+  }
+
+  // Watch this._hass and this.config - with the following, any changes to these properties will call render() again
+  static get properties() {
+    return {
+      _hass: {},
+      config: {},
+    };
   }
 
 // #####


### PR DESCRIPTION
Opening this PR for issue #73 described below:
<hr>

I'm seeing that mostly  `render()` method is called before `set hass(hass)`.
This means that `current()` (called from render) does not have `this._hass` to work upon, so it throws an error, and prevents the rendering of the subsequent html in `render()`.

On making these two changes, my testing has shown good results.
1. In the beginning of `render()`:
    ```JavaScript
    if (!this.config || !this._hass) return html``;  // checking .config is also not a bad idea
    ```
2. With above, we want `render()` to be called again when `set hass(hass)` is called.
This can be done by _watching_ `this._hass` property, and the following getter will do that:
    ```JavaScript
    static get properties() {
      return {
       _hass: {},
       config: {},
      };
    }
    ```